### PR TITLE
kria: dts: set regulator-always-on for regulators

### DIFF
--- a/xlnx-kria-firmware/k26/system.dts
+++ b/xlnx-kria-firmware/k26/system.dts
@@ -808,12 +808,14 @@
 					buck1 {
 						regulator-name = "da9131_buck1";
 						regulator-boot-on;
+						regulator-always-on;
 						phandle = <0x57>;
 					};
 
 					buck2 {
 						regulator-name = "da9131_buck2";
 						regulator-boot-on;
+						regulator-always-on;
 						phandle = <0x58>;
 					};
 				};
@@ -829,6 +831,7 @@
 					buck1 {
 						regulator-name = "da9130_buck1";
 						regulator-boot-on;
+						regulator-always-on;
 						phandle = <0x5a>;
 					};
 				};


### PR DESCRIPTION
This is required due to changes in latest kernels regulator framework.